### PR TITLE
linking now persists between powercycles with the power of protobuf

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,7 +351,10 @@ class ButtonThread : public OSThread
     static void userButtonMultiPressed()
     {
 #ifndef NO_ESP32
-        clearNVS();
+        devicestate.is_linked = false;
+        devicestate.linked_id = INT32_MAX;
+        nodeDB.saveToDisk();
+        //clearNVS();
 #endif
 #ifdef NRF52_SERIES
         clearBonds();

--- a/src/plugins/TextMessagePlugin.cpp
+++ b/src/plugins/TextMessagePlugin.cpp
@@ -22,14 +22,16 @@ ProcessMessage TextMessagePlugin::handleReceived(const MeshPacket &mp)
         triggerPlugin->reqd_from = mp.from;
     }
     else if(strcmp(cmd, "linkAck") == 0){
-        triggerPlugin->isLinked = true;
-        triggerPlugin->linked_id = mp.from;
+        devicestate.is_linked = true;
+        devicestate.linked_id = mp.from;
+        nodeDB.saveToDisk();
         cannedMessagePlugin->sendText(mp.from, "linkConf", false);
         cannedMessagePlugin->sendText(NODENUM_BROADCAST, "reqComp", false);
     }
     else if(strcmp(cmd, "linkConf") == 0){
-        triggerPlugin->isLinked = true;
-        triggerPlugin->linked_id = mp.from;
+        devicestate.is_linked = true;
+        devicestate.linked_id = mp.from;
+        nodeDB.saveToDisk();
     }
     else if(strcmp(cmd, "reqComp") == 0){
         triggerPlugin->linkReqd = false;

--- a/src/plugins/TriggerPlugin.cpp
+++ b/src/plugins/TriggerPlugin.cpp
@@ -11,16 +11,16 @@ TriggerPlugin::TriggerPlugin() : concurrency::OSThread("trigger"){
 
 void TriggerPlugin::AttemptLink()
 {
-    if(!linkReqd){
-        cannedMessagePlugin->sendText(NODENUM_BROADCAST, "linkReq", false);
-    }else{
-        cannedMessagePlugin->sendText(reqd_from, "linkAck", false);
-    }
+        if(!linkReqd){
+            cannedMessagePlugin->sendText(NODENUM_BROADCAST, "linkReq", false);
+        }else{
+            cannedMessagePlugin->sendText(reqd_from, "linkAck", false);
+        }
 }
 
 void TriggerPlugin::SendTrigger(){
-    if(isLinked){
-        cannedMessagePlugin->sendText(linked_id, "trigger", false);
+    if(devicestate.is_linked){
+        cannedMessagePlugin->sendText(devicestate.linked_id, "trigger", false);
     }
 }
 

--- a/src/plugins/TriggerPlugin.h
+++ b/src/plugins/TriggerPlugin.h
@@ -7,10 +7,8 @@ class TriggerPlugin:private concurrency::OSThread
 {
   public:
     bool isAttemptingLink = false;
-    bool isLinked = false;
     bool hasReceivedLinkConf = false;
     unsigned int reqd_from = __UINT32_MAX__;
-    unsigned int linked_id = __UINT32_MAX__;
     bool linkReqd = false;
 
     /** Constructor


### PR DESCRIPTION
You can also now tripple tap button to unlink a device